### PR TITLE
Push dependency fixes to the legacy module too

### DIFF
--- a/manifests/master/dependencies/rubygems.pp
+++ b/manifests/master/dependencies/rubygems.pp
@@ -22,8 +22,18 @@ class classroom_legacy::master::dependencies::rubygems {
     ensure   => '1.6.8.1',
     provider => gem,
   }
+  package { 'rack':
+    ensure   => '1.6.8',
+    provider => gem,
+  }
+  package { 'rack-contrib':
+    ensure   => '1.8.0',
+    provider => gem,
+  }
 
   # This is a soft relationship. It won't fail if showoff isn't included.
   Package['nokogiri']      -> Package<| title == 'showoff' |>
   Package['public_suffix'] -> Package<| title == 'showoff' |>
+  Package['rack']          -> Package<| title == 'showoff' |>
+  Package['rack-contrib']  -> Package<| title == 'showoff' |>
 }


### PR DESCRIPTION
We fixed these in classroom, but not classroom_legacy. I will be glad when this shim goes away in a couple weeks.
  